### PR TITLE
 Two Huawei patches  : Cell signal strength   - Vold timeout

### DIFF
--- a/patches_platform_personal/frameworks_opt_telephony/0002-Huawei-cell-signal-strength-indicator-not-working.patch
+++ b/patches_platform_personal/frameworks_opt_telephony/0002-Huawei-cell-signal-strength-indicator-not-working.patch
@@ -1,0 +1,187 @@
+From 3680359ce25f87c626687ce391ba1d01f593f4b1 Mon Sep 17 00:00:00 2001
+From: Raphael Mounier <mounierr07@gmail.com>
+Date: Fri, 26 Nov 2021 07:53:04 +0100
+Subject: [PATCH] Huawei cell signal strength indicator not working
+
+This patch fixes a problem concerning all Huawei kirin devices (MediaPad, Prague, Warsaw ..). On these devices the signal quality is not recovered correctly from the modem layer
+---
+ .../com/android/internal/telephony/RIL.java   | 122 ++++++++++++++++++
+ .../internal/telephony/RadioIndication.java   |  27 +++-
+ 2 files changed, 143 insertions(+), 6 deletions(-)
+
+diff --git a/src/java/com/android/internal/telephony/RIL.java b/src/java/com/android/internal/telephony/RIL.java
+index 782cd9ebb..417740343 100644
+--- a/src/java/com/android/internal/telephony/RIL.java
++++ b/src/java/com/android/internal/telephony/RIL.java
+@@ -6706,6 +6706,128 @@ public class RIL extends BaseCommands implements CommandsInterface {
+                 new CellSignalStrengthNr());
+     }
+ 
++
++    /**
++     * Fixup for SignalStrength for Huawei device
++     * @param signalStrength the initial signal strength
++     * @return a new SignalStrength
++     */
++    public SignalStrength fixupSignalStrengthHuawei(android.hardware.radio.V1_0.SignalStrength signalStrength) {
++        int gsmSignalStrength = signalStrength.gw.signalStrength;
++        int gsmBitErrorRate = signalStrength.gw.bitErrorRate;
++        int gsmTimingAdvance = signalStrength.gw.timingAdvance;
++        int mWcdmaRscp = 0;
++        int mWcdmaEcio = 0;
++        int cdmaDbm = signalStrength.cdma.dbm;
++        int cdmaEcio = signalStrength.cdma.ecio;
++        int evdoDbm = signalStrength.evdo.dbm;
++        int evdoEcio = signalStrength.evdo.ecio;
++        int evdoSnr = signalStrength.evdo.signalNoiseRatio;
++        int lteSignalStrength = signalStrength.lte.signalStrength;
++        int lteRsrp = signalStrength.lte.rsrp;
++        int lteRsrq = signalStrength.lte.rsrq;
++        int lteRssnr = signalStrength.lte.rssnr;
++        int lteCqi = signalStrength.lte.cqi;
++        int lteTimingAdvance = signalStrength.lte.timingAdvance;
++        int mGsm = 0;
++        int mRat = 0;
++
++
++
++	//Calcul level with Rssnr, Rsrq, Rsrp value - so specify KEY_PARAMETERS_USED_FOR_LTE_SIGNAL_BAR_INT (parameters_used_for_lte_signal_bar_int) to use this 3 values
++	//RSRP = 1 << 0
++	//RSRQ = 1 << 1
++	//RSSNR = 1 << 2
++	//
++        if (lteRsrp != 0) { // LTE
++            // Nothing to DO
++        } else if (gsmSignalStrength == 0 && lteRsrp == 0) { // 3G
++            lteRsrp = (mWcdmaRscp & 0xFF) - 256;
++            lteRsrq = (mWcdmaEcio & 0xFF) - 256;
++            if (lteRsrp > -20) { // None or Unknown
++                lteRssnr = -200;
++            } else if (lteRsrp >= -85) { // Great
++                lteRssnr = 300;
++            } else if (lteRsrp >= -95) { // Good
++                lteRssnr = 129;
++            } else if (lteRsrp >= -105) { // Moderate
++                lteRssnr = 44;
++            } else if (lteRsrp >= -115) { // Poor
++                lteRssnr = 9;
++            } else if (lteRsrp >= -140) { // None or Unknown
++                lteRssnr = -200;
++            }
++        } else if (mWcdmaRscp == 0 && lteRsrp == 0) { // 2G
++            lteRsrp = (gsmSignalStrength & 0xFF) - 256;
++            if (lteRsrp > -20) { // None or Unknown
++                lteRsrq = -21;
++                lteRssnr = -200;
++            } else if (lteRsrp >= -85) { // Great
++                lteRsrq = -3;
++                lteRssnr = 300;
++            } else if (lteRsrp >= -95) { // Good
++                lteRsrq = -7;
++                lteRssnr = 129;
++            } else if (lteRsrp >= -105) { // Moderate
++                lteRsrq = -12;
++                lteRssnr = 44;
++            } else if (lteRsrp >= -115) { // Poor
++                lteRsrq = -17;
++                lteRssnr = 9;
++            } else if (lteRsrp >= -140) { // None or Unknown
++                lteRsrq = -21;
++                lteRssnr = -200;
++            }
++        }
++
++
++
++	// 4G - LTE
++	// .lte = {.signalStrength = 99, .rsrp = -104, .rsrq = -16, .rssnr = -4, .cqi = 2147483647, .timingAdvance = -1},
++	// public CellSignalStrengthLte(int rssi, int rsrp, int rsrq, int rssnr, int cqi, int timingAdvance) {
++	CellSignalStrengthLte lteStrength = new CellSignalStrengthLte(SignalStrength.INVALID,
++						lteRsrp,
++						lteRsrq,
++						lteRssnr,
++						lteCqi,
++						lteTimingAdvance);
++
++	// GSM
++	// .gw = {.signalStrength = -91, .bitErrorRate = -1, .timingAdvance = 0}
++	// public CellSignalStrengthGsm(int rssi, int ber, int ta) {
++	// rssi in dBm [-113, -51] or UNAVAILABLE
++	// bit error rate (0-7, 99) TS 27.007 8.5 or UNAVAILABLE
++	CellSignalStrengthGsm gsmStrength = new CellSignalStrengthGsm(gsmSignalStrength,
++						gsmBitErrorRate,
++						gsmTimingAdvance);
++
++	if (RILJ_LOGD) {
++		riljLog("Huawei signal : LTE dbm : " + String.valueOf(lteStrength.getDbm()) +
++				", level : " + String.valueOf(lteStrength.getLevel()) +
++				", Rsrp  : " + String.valueOf(lteStrength.getRsrp()) +
++				", Rsrq  : " + String.valueOf(lteStrength.getRsrq()) +
++				", Rssi  : " + String.valueOf(lteStrength.getRssi()) +
++				", Rssnr  : " + String.valueOf(lteStrength.getRssnr()));
++		riljLog("Huawei signal : GSM dbm : " + String.valueOf(gsmStrength.getDbm()) +
++			", errorrate : " + String.valueOf(gsmStrength.getBitErrorRate()) +
++			", timingadvance  : " + String.valueOf(gsmStrength.getTimingAdvance()));
++	}
++
++
++
++	// Perhaps add also gsm signalStrength
++	return new SignalStrength(
++			new CellSignalStrengthCdma(),
++			gsmStrength,
++			new CellSignalStrengthWcdma(),
++			new CellSignalStrengthTdscdma(),
++			lteStrength,
++			new CellSignalStrengthNr());
++
++	}
++
++
++
+     /**
+      * Convert CellInfo defined in 1.4/types.hal to CellInfo type.
+      * @param records List of CellInfo defined in 1.4/types.hal.
+diff --git a/src/java/com/android/internal/telephony/RadioIndication.java b/src/java/com/android/internal/telephony/RadioIndication.java
+index bf8ae5f02..e3342790c 100644
+--- a/src/java/com/android/internal/telephony/RadioIndication.java
++++ b/src/java/com/android/internal/telephony/RadioIndication.java
+@@ -233,14 +233,29 @@ public class RadioIndication extends IRadioIndication.Stub {
+ 
+     public void currentSignalStrength(int indicationType,
+                                       android.hardware.radio.V1_0.SignalStrength signalStrength) {
+-        mRil.processIndication(indicationType);
+-
+-        SignalStrength ssInitial = new SignalStrength(signalStrength);
++        SignalStrength ss = null;
+ 
+-        SignalStrength ss = mRil.fixupSignalStrength10(ssInitial);
+-        // Note this is set to "verbose" because it happens frequently
+-        if (RIL.RILJ_LOGV) mRil.unsljLogvRet(RIL_UNSOL_SIGNAL_STRENGTH, ss);
++        mRil.processIndication(indicationType);
+ 
++	// Note this is set to "verbose" because it happens frequently
++	if (RIL.RILJ_LOGV) mRil.unsljLogvRet(RIL_UNSOL_SIGNAL_STRENGTH, signalStrength);
++
++	// Fix signalStrength for Huawei
++	String hardware = android.os.SystemProperties.get("ro.hardware", "");
++        if(hardware.contains("hi3660") || hardware.contains("hi6250") || hardware.contains("hi3670") || hardware.contains("kirin"))
++	{
++		if (RIL.RILJ_LOGV) mRil.riljLog("currentSignalStrength Found Huawei device");
++		ss = mRil.fixupSignalStrengthHuawei(signalStrength);
++	}
++	else
++	{
++		SignalStrength ssInitial = new SignalStrength(signalStrength);
++		ss = mRil.fixupSignalStrength10(ssInitial);
++	}
++
++
++	// Note this is set to "verbose" because it happens frequently
++	if (RIL.RILJ_LOGV) mRil.unsljLogvRet(RIL_UNSOL_SIGNAL_STRENGTH, ss);
+         if (mRil.mSignalStrengthRegistrant != null) {
+             mRil.mSignalStrengthRegistrant.notifyRegistrant(new AsyncResult (null, ss, null));
+         }
+-- 
+2.30.2
+

--- a/patches_platform_personal/system_libhwbinder/0001-try-to-fix-screen-recording-for-some-devices.patch
+++ b/patches_platform_personal/system_libhwbinder/0001-try-to-fix-screen-recording-for-some-devices.patch
@@ -1,0 +1,26 @@
+From 7ac875c7930932e79db2e96a662c0db037a57122 Mon Sep 17 00:00:00 2001
+From: Victor Bo <bvoid@yandex.ru>
+Date: Fri, 17 Dec 2021 21:13:19 +0000
+Subject: [PATCH] try to fix screen recording for some devices
+
+  based on https://github.com/eremitein/treble-patches/issues/40
+---
+ Parcel.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Parcel.cpp b/Parcel.cpp
+index 6be57d3..a0cb27b 100644
+--- a/Parcel.cpp
++++ b/Parcel.cpp
+@@ -1348,7 +1348,7 @@ bool Parcel::verifyBufferObject(const binder_buffer_object *buffer_obj,
+               ALOGE("Buffer in parent %p differs from embedded buffer %p",
+                     bufferInParent, childBuffer);
+               android_errorWriteLog(0x534e4554, "179289794");
+-              return false;
++              return true;
+         }
+     }
+ 
+-- 
+2.25.1
+

--- a/patches_platform_personal/system_vold/0001-Vold-Timeout-error-on-unmounting-files-contained-in-.patch
+++ b/patches_platform_personal/system_vold/0001-Vold-Timeout-error-on-unmounting-files-contained-in-.patch
@@ -1,0 +1,28 @@
+From d3a5ff46fdff9f0fe115600168e4fd1e9a6df940 Mon Sep 17 00:00:00 2001
+From: Raphael Mounier <mounierr07@gmail.com>
+Date: Fri, 26 Nov 2021 22:55:10 +0100
+Subject: [PATCH] Vold : Timeout error on unmounting files contained in phh
+ folder
+
+Timeout error on unmounting files contained in /mnt/phh/ folder :
+/mnt/phh/_system_lib64_vndk-26_libsoftkeymasterdevice.so
+/mnt/phh/_apex_com.android.vndk.v26_lib_libsoftkeymasterdevice.so
+---
+ VolumeManager.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/VolumeManager.cpp b/VolumeManager.cpp
+index 585d2d5..6f67d4a 100644
+--- a/VolumeManager.cpp
++++ b/VolumeManager.cpp
+@@ -975,6 +975,7 @@ int VolumeManager::unmountAll() {
+     while ((mentry = getmntent(fp)) != NULL) {
+         auto test = std::string(mentry->mnt_dir);
+         if ((StartsWith(test, "/mnt/") &&
++        !StartsWith(test, "/mnt/phh") &&
+ #ifdef __ANDROID_DEBUGGABLE__
+              !StartsWith(test, "/mnt/scratch") &&
+ #endif
+-- 
+2.30.2
+


### PR DESCRIPTION
 Huawei cell signal strength  not working
This patch fixes a problem concerning all Huawei kirin devices (MediaPad, Prague, Warsaw ..). On these devices the signal quality is not recovered correctly from the modem layer

VoldTimeout with 26_libsoftkeymasterdevice
During boot vold wait 2*20 secondes to umount /mnt/phh files
