### PR TITLE
Changes for June 2023, syncing up to 20230610

### DIFF
--- a/patches_treble/device_phh_treble/0001-treble-Lineage-ify.patch
+++ b/patches_treble/device_phh_treble/0001-treble-Lineage-ify.patch
@@ -1,7 +1,7 @@
-From ea3fbad21a0874e5215003596cebc63ace7066c5 Mon Sep 17 00:00:00 2001
+From adb5d31bb61acfd2633dfbdf1539dd820004d1fd Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Sun, 8 Aug 2021 01:43:40 +0000
-Subject: [PATCH 1/9] treble: Lineage-ify
+Subject: [PATCH 01/10] treble: Lineage-ify
 
 Squash of:
 - Proper target names
@@ -29,7 +29,7 @@ index 6a317e4..e69de29 100644
 -PRODUCT_COPY_FILES += \
 -	device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.xml
 diff --git a/base.mk b/base.mk
-index 348799e..17bfdc3 100644
+index b9298a2..c1b8ef4 100644
 --- a/base.mk
 +++ b/base.mk
 @@ -17,12 +17,14 @@ PRODUCT_COPY_FILES += \

--- a/patches_treble/device_phh_treble/0002-treble-Set-BOARD_EXT4_SHARE_DUP_BLOCKS-explicitly.patch
+++ b/patches_treble/device_phh_treble/0002-treble-Set-BOARD_EXT4_SHARE_DUP_BLOCKS-explicitly.patch
@@ -1,7 +1,7 @@
-From cdc58cf7521058bf50f6835fa41a2cedc6dab008 Mon Sep 17 00:00:00 2001
+From 6dac672bb28fbd623e0624b60a6f067cd4ea7e06 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Sun, 8 Aug 2021 09:29:32 +0000
-Subject: [PATCH 2/9] treble: Set BOARD_EXT4_SHARE_DUP_BLOCKS explicitly
+Subject: [PATCH 02/10] treble: Set BOARD_EXT4_SHARE_DUP_BLOCKS explicitly
 
 Change-Id: I725443154fabde548d2e6c1b072d34c27596c421
 ---

--- a/patches_treble/device_phh_treble/0003-treble-Set-TARGET_NO_KERNEL_OVERRIDE.patch
+++ b/patches_treble/device_phh_treble/0003-treble-Set-TARGET_NO_KERNEL_OVERRIDE.patch
@@ -1,7 +1,7 @@
-From 637ec8c42fd5946eb7e9df549b980d605b22dad6 Mon Sep 17 00:00:00 2001
+From d76dcecde10c800d24afb5bffa579013037c72a4 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Wed, 20 Oct 2021 11:30:25 +0000
-Subject: [PATCH 3/9] treble: Set TARGET_NO_KERNEL_OVERRIDE
+Subject: [PATCH 03/10] treble: Set TARGET_NO_KERNEL_OVERRIDE
 
 Taken from Lineage generic targets - skips building kernel cleanly
 

--- a/patches_treble/device_phh_treble/0004-treble-Enable-call-recording.patch
+++ b/patches_treble/device_phh_treble/0004-treble-Enable-call-recording.patch
@@ -1,7 +1,7 @@
-From eec1dc55bfe0733d1c6d8a5d870cd6411b02bd0d Mon Sep 17 00:00:00 2001
+From efff0ae08fbdb719e2bc513eca1ea993639b9610 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Tue, 11 Oct 2022 11:29:02 +0000
-Subject: [PATCH 4/9] treble: Enable call recording
+Subject: [PATCH 04/10] treble: Enable call recording
 
 Change-Id: I57ca3604363547419a566b37b5151b6b30c46d28
 ---

--- a/patches_treble/device_phh_treble/0005-treble-Switch-to-MindTheGapps.patch
+++ b/patches_treble/device_phh_treble/0005-treble-Switch-to-MindTheGapps.patch
@@ -1,7 +1,7 @@
-From be808ccab89637aa591c6ec13ab6187848e2c55c Mon Sep 17 00:00:00 2001
+From b9896861bd232d069c897b088bdfd8fd59748622 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Sat, 5 Nov 2022 23:49:11 +0000
-Subject: [PATCH 5/9] treble: Switch to MindTheGapps
+Subject: [PATCH 05/10] treble: Switch to MindTheGapps
 
 Change-Id: I1b80d4c5176cbf4af21d147c71b0abce6027c7c7
 ---

--- a/patches_treble/device_phh_treble/0006-treble-Stop-securing-ADB.patch
+++ b/patches_treble/device_phh_treble/0006-treble-Stop-securing-ADB.patch
@@ -1,7 +1,7 @@
-From 4901e97f452afa7eccffa22d50d6ccaa7eae8ffe Mon Sep 17 00:00:00 2001
+From f880d2aac66693801bea5c6eb7c9ff2b3b32e1ab Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Tue, 22 Nov 2022 00:36:15 +0000
-Subject: [PATCH 6/9] treble: Stop securing ADB
+Subject: [PATCH 06/10] treble: Stop securing ADB
 
 Seems to kill USB Debugging altogether on certain devices,
 and unrelated to SN anyway
@@ -9,14 +9,14 @@ Build-time macro coupled with vendor/lineage might do better...
 
 Change-Id: I0215b3ed970dd53a124f48e30ca2cf4b0c6d2899
 ---
- rw-system.sh | 4 ----
- 1 file changed, 4 deletions(-)
+ rw-system.sh | 3 ---
+ 1 file changed, 3 deletions(-)
 
 diff --git a/rw-system.sh b/rw-system.sh
-index e1ad994..d78655e 100644
+index 5dc493f..9c7cc42 100644
 --- a/rw-system.sh
 +++ b/rw-system.sh
-@@ -772,14 +772,10 @@ if [ -f /system/phh/secure ] || [ -f /metadata/phh/secure ];then
+@@ -776,13 +776,10 @@ if [ -f /system/phh/secure ] || [ -f /metadata/phh/secure ];then
      resetprop_phh ro.boot.veritymode enforcing
      resetprop_phh ro.boot.warranty_bit 0
      resetprop_phh ro.warranty_bit 0
@@ -26,7 +26,6 @@ index e1ad994..d78655e 100644
      resetprop_phh ro.build.selinux 0
  
 -    resetprop_phh ro.adb.secure 1
--    setprop ctl.restart adbd
 -
      # Hide system/xbin/su
      mount /mnt/phh/empty_dir /system/xbin

--- a/patches_treble/device_phh_treble/0007-treble-Securize-on-demand.patch
+++ b/patches_treble/device_phh_treble/0007-treble-Securize-on-demand.patch
@@ -1,21 +1,20 @@
-From 4a2ed5f6bf414ac6d493f78c0ad89572b1aef5f2 Mon Sep 17 00:00:00 2001
+From 1e3403567b882b4c655b74b21522d08c1183b48b Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Thu, 29 Dec 2022 15:12:03 +0000
-Subject: [PATCH 7/9] treble: Securize on-demand
+Subject: [PATCH 07/10] treble: Securize on-demand
 
 Status is stored in /metadata and controlled by persist prop
 
 Change-Id: I8069b6f471ad87ab34c18b743689ab3584cee35b
 ---
  phh-prop-handler.sh | 14 ++++++++++++++
- vndk.rc             |  2 ++
- 2 files changed, 16 insertions(+)
+ 1 file changed, 14 insertions(+)
 
 diff --git a/phh-prop-handler.sh b/phh-prop-handler.sh
-index 4371632..a8cea3f 100644
+index 24056e4..8dd75be 100644
 --- a/phh-prop-handler.sh
 +++ b/phh-prop-handler.sh
-@@ -210,3 +210,17 @@ if [ "$1" == "persist.sys.phh.disable_soundvolume_effect" ];then
+@@ -228,3 +228,17 @@ if [ "$1" == "persist.bluetooth.system_audio_hal.enabled" ]; then
      restartAudio
      exit
  fi
@@ -33,16 +32,6 @@ index 4371632..a8cea3f 100644
 +    fi
 +    exit
 +fi
-diff --git a/vndk.rc b/vndk.rc
-index d1fffde..7db62b7 100644
---- a/vndk.rc
-+++ b/vndk.rc
-@@ -82,3 +82,5 @@ on property:sys.phh.uninstall-ota=true
- on property:ro.vendor.radio.default_network=*
-     setprop ro.telephony.default_network ${ro.vendor.radio.default_network}
- 
-+on property:persist.sys.phh.securize=*
-+    exec u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.securize"
 -- 
 2.34.1
 

--- a/patches_treble/device_phh_treble/0008-treble-Also-use-data-adb-for-securize-status.patch
+++ b/patches_treble/device_phh_treble/0008-treble-Also-use-data-adb-for-securize-status.patch
@@ -1,7 +1,7 @@
-From c8537ab48366a14bf90706fc44667fc1b6003b73 Mon Sep 17 00:00:00 2001
+From d3acdb0c644b88e9ee8209e9280181d6975d04c3 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Wed, 22 Mar 2023 23:37:05 +0000
-Subject: [PATCH 8/9] treble: Also use /data/adb for securize status
+Subject: [PATCH 08/10] treble: Also use /data/adb for securize status
 
 Change-Id: I778f2be5407ae0a548a098c72031cce9be83cf96
 ---
@@ -10,10 +10,10 @@ Change-Id: I778f2be5407ae0a548a098c72031cce9be83cf96
  2 files changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/phh-prop-handler.sh b/phh-prop-handler.sh
-index a8cea3f..3739eb4 100644
+index 8dd75be..a4103eb 100644
 --- a/phh-prop-handler.sh
 +++ b/phh-prop-handler.sh
-@@ -217,10 +217,13 @@ if [ "$1" == "persist.sys.phh.securize" ];then
+@@ -235,10 +235,13 @@ if [ "$1" == "persist.sys.phh.securize" ];then
      fi
  
      if [[ "$prop_value" == "true" ]]; then
@@ -29,10 +29,10 @@ index a8cea3f..3739eb4 100644
      exit
  fi
 diff --git a/rw-system.sh b/rw-system.sh
-index d78655e..7291547 100644
+index 9c7cc42..8a188f7 100644
 --- a/rw-system.sh
 +++ b/rw-system.sh
-@@ -735,7 +735,7 @@ copyprop() {
+@@ -739,7 +739,7 @@ copyprop() {
          resetprop_phh "$1" "$(getprop "$2")"
      fi
  }

--- a/patches_treble/device_phh_treble/0009-treble-Include-androidx.window.extensions.patch
+++ b/patches_treble/device_phh_treble/0009-treble-Include-androidx.window.extensions.patch
@@ -1,7 +1,7 @@
-From 267d881c8ad8a6626ea64768b20e0a86897091a8 Mon Sep 17 00:00:00 2001
+From 46d6ba0f5283270bec6e0d69391d91752b08d718 Mon Sep 17 00:00:00 2001
 From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
 Date: Fri, 24 Mar 2023 00:13:01 +0000
-Subject: [PATCH 9/9] treble: Include androidx.window.extensions
+Subject: [PATCH 09/10] treble: Include androidx.window.extensions
 
 This enables two-pane layout in Settings for tablets
 
@@ -11,10 +11,10 @@ Change-Id: I2503c1c510151ea8463c86521a9164727467c551
  1 file changed, 4 insertions(+)
 
 diff --git a/base.mk b/base.mk
-index 17bfdc3..49c4da6 100644
+index c1b8ef4..cfbf288 100644
 --- a/base.mk
 +++ b/base.mk
-@@ -255,3 +255,7 @@ PRODUCT_COPY_FILES += \
+@@ -258,3 +258,7 @@ PRODUCT_COPY_FILES += \
  # QCOM in-call audio fix as a standalone app
  PRODUCT_PACKAGES += \
      QcRilAm

--- a/patches_treble/device_phh_treble/0010-treble-Fix-duplicate-battery_scale-error.patch
+++ b/patches_treble/device_phh_treble/0010-treble-Fix-duplicate-battery_scale-error.patch
@@ -1,0 +1,25 @@
+From 85f51abaf87a40a77fbb653bfed1be8da9dec39e Mon Sep 17 00:00:00 2001
+From: Damien Merenne <dam@cosinux.org>
+Date: Mon, 12 Jun 2023 11:27:37 +0200
+Subject: [PATCH 10/10] treble: Fix duplicate battery_scale error
+
+Change-Id: Ie1e61215b46bfb218665743b1f74b969c6d4353b
+---
+ board-base.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/board-base.mk b/board-base.mk
+index 9d1d45e..f383ba5 100644
+--- a/board-base.mk
++++ b/board-base.mk
+@@ -8,6 +8,7 @@ DEVICE_FRAMEWORK_MANIFEST_FILE := device/phh/treble/framework_manifest.xml
+ 
+ BOARD_ROOT_EXTRA_FOLDERS += bt_firmware sec_storage efs persist
+ BUILD_BROKEN_ELF_PREBUILT_PRODUCT_COPY_FILES := true
++BUILD_BROKEN_DUP_RULES := true
+ 
+ BOARD_ROOT_EXTRA_SYMLINKS := $(filter-out $(BOARD_ROOT_EXTRA_SYMLINKS),/mnt/vendor/persist:/persist)
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Hello,

I was trying to build the td image and I add to update the patches so that they build against latest Lineage/TrebleDroid. I'm pretty certain the `+BUILD_BROKEN_DUP_RULES := true` is not the fix that should be there but without it, the build would fail with an error about duplicate rule for `battery_scale.png`

I just wanted to give you a heads up for your next update, thanks for your work!